### PR TITLE
Don't delete /tmp completely, only it's contents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -yq --purge \
     && DEBIAN_FRONTEND=noninteractive apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp
+    && rm -rf /tmp/*


### PR DESCRIPTION
This prevents problems with 'apt-get update' in containers which derive from this container.